### PR TITLE
Version 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Environmental Variables
 env*
-./config.j*
+config.j*
 brain.json
 
 # Logs

--- a/config.json
+++ b/config.json
@@ -1,5 +1,0 @@
-{
-  "google_api": "AIzaSyDRwP-Edb3xWDoZmOhFDGUxyiRNFUvO5-w",
-  "token": "MjA3NTc2NTI4MTYxMDc5Mjk2.Cnlv6A.B6bDcChraW2jengbM0FHwegvoDw",
-  "brain": "/storage/"
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootler",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A discord bot, written in javascript.",
   "main": "./src/Server.js",
   "scripts": {
@@ -26,13 +26,13 @@
   "devDependencies": {
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.11.6",
-    "mocha": "^2.5.3"
+    "mocha": "^3.0.0"
   },
   "dependencies": {
     "discord.js": "^8.0.0",
     "fs-extra": "^0.30.0",
     "request": "^2.74.0",
     "roll": "^1.1.0",
-    "walk-sync": "^0.2.7"
+    "walk-sync": "^0.3.0"
   }
 }

--- a/plugins/search.js
+++ b/plugins/search.js
@@ -1,4 +1,3 @@
-const request = require('request');
 const fs = require('fs-extra');
 
 module.exports = function(engine) {
@@ -7,7 +6,7 @@ module.exports = function(engine) {
   engine.on( /^(?:who|what) is (.+)\?$/i, function(message, params, send) {
     let search = params[1];
     let url = "https://kgsearch.googleapis.com/v1/entities:search?query={query}&key={key}&limit=1&indent=True";
-    request.get(url.replace("{query}", search).replace("{key}", apikey),
+    engine.http.get(url.replace("{query}", search).replace("{key}", apikey),
       function (error, response, body) {
         if (!error && response.statusCode == 200) {
           let data = JSON.parse(body);

--- a/plugins/steam.js
+++ b/plugins/steam.js
@@ -1,11 +1,9 @@
-let request = require('request');
-
 module.exports = function (robot) {
   var url = "http://store.steampowered.com/search/suggest?term={{term}}&f=games&cc=CA&l=english&v=1127612"
   var parse = /match_name">([^<]+)<\/div>.*?CDN&#36; (\d+\.\d+)/gi
 
   robot.respond(/steam (.+)/i, function (message, params, send) {
-    request(url.replace("{{term}}", params[1]), function (err, _, body) {
+    robot.http(url.replace("{{term}}", params[1]), function (err, _, body) {
       if (err) {
         send("Encountered an error :\n" + err);
         return;
@@ -30,7 +28,7 @@ module.exports = function (robot) {
   })
 
   robot.respond( /what'?s (on sale|featured|on steam)\??$/i, function(message, params, send) {
-    request('http://store.steampowered.com/api/featured?cc=CA', function(err, _, body) {
+    robot.http('http://store.steampowered.com/api/featured?cc=CA', function(err, _, body) {
       if(err) {
         send("Encountered an error\n", err);
         return;

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -10,6 +10,7 @@ module.exports = class Engine {
     for(let i = 0; i < this._plugins.length; i++) {
       this._plugins[i](this); // startup.
     }
+    this.http = require('request');
   }
 
   ////


### PR DESCRIPTION
- Updated mocha, and walk-sync dependancies
- `engine.http` now is a `request` object
- migrated existing plugins to `engine.http`
- Fixed `.gitignore` to work for Windows
- Removed and invalidated Google and Discord api keys, lets not do that
  again... On the plus side there is now an example of a valid config
  file.
- Version bump to 1.2.0
